### PR TITLE
Add support for isnull on key/value pairs

### DIFF
--- a/django_hstore/fields.py
+++ b/django_hstore/fields.py
@@ -78,6 +78,7 @@ if get_version() >= '1.7':
     HStoreField.register_lookup(HStoreLessThanOrEqual)
     HStoreField.register_lookup(HStoreContains)
     HStoreField.register_lookup(HStoreIContains)
+    HStoreField.register_lookup(HStoreIsNull)
 
 
 class DictionaryField(HStoreField):

--- a/doc/doc.asciidoc
+++ b/doc/doc.asciidoc
@@ -434,6 +434,13 @@ Something.objects.filter(data__contains=['a', 'b'])
 
 # subset by single key
 Something.objects.filter(data__contains=['a'])
+
+# filter by is null on individual key/value pairs
+Something.objects.filter(data__isnull={'a': True})
+Something.objects.filter(data__isnull={'a': True, 'b': False})
+
+# filter by is null on the column works as normal
+Something.objects.filter(data__isnull=True)
 ----
 
 

--- a/tests/django_hstore_tests/tests.py
+++ b/tests/django_hstore_tests/tests.py
@@ -153,6 +153,18 @@ class TestDictionaryField(TestCase):
         with self.assertRaises(KeyError):
             n.data['test']
 
+    def test_null_values(self):
+        null_v = DataBag.objects.create(name="test", data={"v": None})
+        nonnull_v = DataBag.objects.create(name="test", data={"v": "item"})
+
+        r = DataBag.objects.filter(data__isnull={"v": True})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], null_v)
+
+        r = DataBag.objects.filter(data__isnull={"v": False})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], nonnull_v)
+
     def test_named_querying(self):
         alpha, beta = self._create_bags()
         self.assertEqual(DataBag.objects.get(name='alpha'), alpha)


### PR DESCRIPTION
Builds of off #72 because it also needs to make use of `value_annotations`, but if #72 doesn't get merged this could easily be split off.
