### PR TITLE
Replace iteritems with items

### DIFF
--- a/django_hstore/dict.py
+++ b/django_hstore/dict.py
@@ -102,7 +102,7 @@ class HStoreDict(UnicodeMixin, dict):
         return self.__class__(self, self.field)
 
     def update(self, *args, **kwargs):
-        for key, value in dict(*args, **kwargs).iteritems():
+        for key, value in dict(*args, **kwargs).items():
             self[key] = value
 
     def ensure_acceptable_value(self, value):


### PR DESCRIPTION
There is no `dict.iteritems` in Py3. And in Py2, it really shouldn't make much of a performance difference to use `dict.items`.
