### PR TITLE
Support for a serialized field (preserve data types)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,3 +19,4 @@ Donald Stufft       https://github.com/dstufft
 Mikko Hellsing      https://github.com/aino
 Adieu               https://github.com/adieu
 Alexander Dinu      https://github.com/aluuu
+Anthony Lukach      http://github.com/alukach

--- a/django_hstore/descriptors.py
+++ b/django_hstore/descriptors.py
@@ -4,7 +4,8 @@ from .dict import HStoreDict, HStoreReferenceDict
 
 __all__ = [
     'HStoreDescriptor',
-    'HStoreReferenceDescriptor'
+    'HStoreReferenceDescriptor',
+    'SerializedDictDescriptor'
 ]
 
 
@@ -21,6 +22,18 @@ class HStoreDescriptor(models.fields.subclassing.Creator):
             value = self._DictClass(
                 value=value, field=self.field, instance=obj, schema_mode=self.schema_mode
             )
+        obj.__dict__[self.field.name] = value
+
+
+class SerializedDictDescriptor(models.fields.subclassing.Creator):
+    _DictClass = dict
+
+    def __set__(self, obj, value):
+        # Deserialization is only needed when retrieving data from DB
+        # (not when field is being set via assignment (`x.data = {...}`)
+        # or via the `.create()` method.
+        if value and self.field._from_db(obj):
+            value = self.field.to_python(value)
         obj.__dict__[self.field.name] = value
 
 

--- a/django_hstore/forms.py
+++ b/django_hstore/forms.py
@@ -14,8 +14,8 @@ from .widgets import AdminHStoreWidget
 from . import utils
 
 
-def validate_hstore(value):
-    """ HSTORE validation """
+def validate_hstore(value, is_serialized=False):
+    """ HSTORE validation. """
     # if empty
     if value == '' or value == 'null':
         value = '{}'
@@ -25,6 +25,10 @@ def validate_hstore(value):
         # convert strings to dictionaries
         if isinstance(value, six.string_types):
             dictionary = json.loads(value)
+
+            # if serialized field, deserialize values
+            if is_serialized and isinstance(dictionary, dict):
+                dictionary = dict((k, json.loads(v)) for k, v in dictionary.items())  # TODO: modify to use field's deserializer
         # if not a string we'll check at the next control if it's a dict
         else:
             dictionary = value
@@ -39,8 +43,9 @@ def validate_hstore(value):
     for key, value in dictionary.items():
         if isinstance(value, dict) or isinstance(value, list):
             dictionary[key] = json.dumps(value)
-        elif isinstance(value, bool) or isinstance(value, int) or isinstance(value, float):
-            dictionary[key] = unicode(value).lower()
+        if isinstance(value, bool) or isinstance(value, int) or isinstance(value, float):
+            if not is_serialized:  # Only convert if not from serializedfield
+                dictionary[key] = six.text_type(value).lower()
 
     return dictionary
 
@@ -57,8 +62,27 @@ class JsonMixin(object):
             value = json.dumps(value, sort_keys=True, indent=4)
         return super(JsonMixin, self).render(name, value, attrs)
 
+class SerializedJsonMixin(JsonMixin):
+
+    def to_python(self, value):
+        return validate_hstore(value, is_serialized=True)
+
+    def render(self, name, value, attrs=None):
+        if isinstance(value, dict):
+            value = dict((k, json.dumps(v)) for k, v in value.items())  # TODO: Modify to use field's serializer
+
+        # return json representation of a meaningful value
+        # doesn't show anything for None, empty strings or empty dictionaries
+        if value and not isinstance(value, six.string_types):
+            value = json.dumps(value, sort_keys=True, indent=4)
+        return super(SerializedJsonMixin, self).render(name, value, attrs)
+
 
 class DictionaryFieldWidget(JsonMixin, AdminHStoreWidget):
+    pass
+
+
+class SerializedDictionaryFieldWidget(SerializedJsonMixin, AdminHStoreWidget):
     pass
 
 
@@ -76,6 +100,15 @@ class DictionaryField(JsonMixin, Field):
     def __init__(self, **params):
         params['widget'] = params.get('widget', DictionaryFieldWidget)
         super(DictionaryField, self).__init__(**params)
+
+
+class SerializedDictionaryField(SerializedJsonMixin, Field):
+    """
+    A dictionary form field.
+    """
+    def __init__(self, **params):
+        params['widget'] = params.get('widget', SerializedDictionaryFieldWidget)
+        super(SerializedDictionaryField, self).__init__(**params)
 
 
 class ReferencesField(JsonMixin, Field):

--- a/django_hstore/hstore.py
+++ b/django_hstore/hstore.py
@@ -1,4 +1,4 @@
-from django_hstore.fields import DictionaryField, ReferencesField  # noqa
+from django_hstore.fields import DictionaryField, ReferencesField, SerializedDictionaryField  # noqa
 from django_hstore.managers import HStoreManager  # noqa
 
 
@@ -11,3 +11,4 @@ except:
 import django
 if django.get_version() < '1.7':
     from . import apps  # noqa
+

--- a/django_hstore/lookups.py
+++ b/django_hstore/lookups.py
@@ -113,6 +113,12 @@ class HStoreContains(HStoreLookupMixin, Contains):
             # if looking for a string perform the normal text lookup
             # that is: look for occurence of string in all the keys
             pass
+        elif hasattr(self.lhs.source, 'serializer'):
+            try:
+                self.lhs.source._serialize_value(param)
+                pass
+            except Exception:
+                raise ValueError('invalid value')
         else:
             raise ValueError('invalid value')
         return super(HStoreContains, self).as_sql(qn, connection)

--- a/django_hstore/query.py
+++ b/django_hstore/query.py
@@ -204,6 +204,12 @@ class HStoreWhereNode(WhereNode):
                     # that is: look for occurence of string in all the keys
                     pass
 
+                elif hasattr(child[0].field, 'serializer'):
+                    try:
+                        child[0].field._serialize_value(param)
+                        pass
+                    except Exception:
+                        raise ValueError('invalid value')
                 else:
                     raise ValueError('invalid value')
 
@@ -309,8 +315,10 @@ class HStoreQuerySet(QuerySet):
         """
         Updates the specified hstore.
         """
-        value = QueryWrapper('"%s" || %%s' % attr, [updates])
         field, model, direct, m2m = self.model._meta.get_field_by_name(attr)
+        if hasattr(field, 'serializer'):
+            updates = field.get_prep_value(updates)
+        value = QueryWrapper('"%s" || %%s' % attr, [updates])
         query.add_update_fields([(field, None, value)])
         return query
 

--- a/doc/doc.asciidoc
+++ b/doc/doc.asciidoc
@@ -46,13 +46,17 @@ image:images/hstore-widget.png["Grappeli Widget",width=650]
 .Each time a key or a value is modified, the underlying textarea is updated:
 image:images/hstore-widget-raw.png["Grappeli Widget",width=650]
 
+*Note: When using SerializedDictionaryField, data values are displayed in their
+serialized JSON form. This is done to make their type explicit.
 
 Limitations
 ~~~~~~~~~~~
 
 - PostgreSQL's implementation of hstore has no concept of type; it stores a
   mapping of string keys to string values. Values are stored as strings in the
-  database regarding of their original type. *This limitation can be overcome by using the schema mode since version 1.3.0 of django_hstore*.
+  database regarding of their original type. *This limitation can be overcome by
+  using either the schema mode since version 1.3.0 or by using
+  the serialized dictionary field since version 1.3.6 of django_hstore*.
 - The hstore extension is not automatically installed on use with this package: you must install it manually.
 - To run tests, hstore extension must be installed on template1 database.
   To install hstore on template1: `$ psql -d template1 -c 'create extension hstore;'`
@@ -214,11 +218,16 @@ SOUTH_DATABASE_ADAPTERS = {'default': 'south.db.postgresql_psycopg2'}
 Usage
 ~~~~~
 
-The library provides three principal classes:
+The library provides five principal classes:
 
 - `django_hstore.hstore.DictionaryField` +
   An ORM field which stores a mapping of string key/value pairs in a hstore
   column.
+- `django_hstore.hstore.SerializedDictionaryField` +
+  Similar to the `DictionaryField` with the exception that all submitted values
+  in string key/value are encoded-to JSON upon writes to the database and decoded
+  from JSON upon database reads. This allows for any JSON supported data type to
+  be stored in an hstore column.
 - `django_hstore.hstore.ReferencesField` +
   An ORM field which builds on DictionaryField to store a mapping of string
   keys to django object references, much like ForeignKey.
@@ -240,7 +249,7 @@ from django_hstore import hstore
 
 class Something(models.Model):
     name = models.CharField(max_length=32)
-    data = hstore.DictionaryField()  # can pass attributes like null, blank, ecc.
+    data = hstore.DictionaryField()  # can pass attributes like null, blank, etc.
 
     objects = hstore.HStoreManager()
     # IF YOU ARE USING POSTGIS:
@@ -357,6 +366,29 @@ class ReferenceContainer(models.Model):
     objects = hstore.HStoreManager()
 ----
 
+.the `SerializedDictionaryField` definition is very similar to the standard
+dictionary field:
+[source, python]
+----
+from django.db import models
+from django_hstore import hstore
+
+class Something(models.Model):
+    name = models.CharField(max_length=32)
+    data = hstore.SerializedDictionaryField()  # can pass attributes like null, blank, etc.
+
+    objects = hstore.HStoreManager()
+    # IF YOU ARE USING POSTGIS:
+    # objects = hstore.HStoreGeoManager()
+----
+
+Optionally, the data accepts both a `serializer` and `deserializer` argument
+(which default to `json.dumps` and `json.loads`, respectively).  This allows
+allowing for customized manners of serialization. *Customizing the
+serializer/deserializer is only partially implemented. It is NOT supported with
+the default Django admin widget (which attempts to serialize and deserialize all
+values with `json.dumps` and `json.loads`). Use at your own risk.*
+
 Python API
 ~~~~~~~~~~
 
@@ -418,6 +450,32 @@ Each virtual field will be mapped to a key of the `DictionaryField`:
 9.99
 ----
 
+Since version *1.3.6* you can use the `SerializedDictionaryField` to store any
+data type support in JSON. This has the specific advantage over the schema mode
+of not requiring the user to specify schema ahead of time.
+
+[source, python]
+----
+>>> obj = SerializedExample.objects.create(
+...   name="A Serializable Field!",
+...   data={
+...     'str': 'A string',
+...     'int': 1234,
+...     'float': 3.141,
+...     'bool': True,
+...     'list': [0, 'one', [2.0, 2.1]],
+...     'dict': {
+...       'a': 1,
+...       'b': 'two',
+...       'c': ['three']
+...     }
+...   }
+... )
+
+>>> obj.data
+{'int': 1234, 'float': 3.141, 'list': [0, 'one', [2.0, 2.1]], 'bool': True, 'str': 'A string', 'dict': {'a': 1, 'c': ['three'], 'b': 'two'}
+----
+
 You can issue indexed queries against hstore fields:
 
 [source,python]
@@ -442,12 +500,15 @@ Something.objects.filter(data__lte={'a': '2', 'b: '3'})
 Something.objects.filter(data__contains={'a': '1'})
 
 # subset by list of some key values
+# Note: Incompatible with the SerializedDictionaryField (lists as values are treated as actual values, not subsets)
 Something.objects.filter(data__contains={'a': ['1', '2']})
 
 # subset by list of keys
+# Note: Incompatible with the SerializedDictionaryField (lists as values are treated as actual values, not subsets)
 Something.objects.filter(data__contains=['a', 'b'])
 
 # subset by single key
+# Note: Incompatible with the SerializedDictionaryField (lists as values are treated as actual values, not subsets)
 Something.objects.filter(data__contains=['a'])
 
 # filter by is null on individual key/value pairs

--- a/tests/django_hstore_tests/admin.py
+++ b/tests/django_hstore_tests/admin.py
@@ -21,6 +21,7 @@ class RefsBagAdmin(admin.ModelAdmin):
 
 
 admin.site.register(DataBag, DataBagAdmin)
+admin.site.register(SerializedDataBag, DataBagAdmin)
 admin.site.register(DefaultsModel, DefaultsModelAdmin)
 admin.site.register(RefsBag, RefsBagAdmin)
 

--- a/tests/django_hstore_tests/models.py
+++ b/tests/django_hstore_tests/models.py
@@ -11,6 +11,7 @@ GEODJANGO = settings.DATABASES['default']['ENGINE'] == 'django.contrib.gis.db.ba
 __all__ = [
     'Ref',
     'DataBag',
+    'SerializedDataBag',
     'NullableDataBag',
     'RefsBag',
     'NullableRefsBag',
@@ -37,6 +38,11 @@ class HStoreModel(models.Model):
 class DataBag(HStoreModel):
     name = models.CharField(max_length=32)
     data = hstore.DictionaryField()
+
+
+class SerializedDataBag(HStoreModel):
+    name = models.CharField(max_length=32)
+    data = hstore.SerializedDictionaryField()
 
 
 class NullableDataBag(HStoreModel):

--- a/tests/django_hstore_tests/tests.py
+++ b/tests/django_hstore_tests/tests.py
@@ -18,7 +18,7 @@ from django.test import TestCase
 from django.test import SimpleTestCase
 
 from django_hstore import get_version, hstore
-from django_hstore.forms import DictionaryFieldWidget, ReferencesFieldWidget
+from django_hstore.forms import DictionaryFieldWidget, ReferencesFieldWidget, SerializedDictionaryFieldWidget
 from django_hstore.fields import HStoreDict
 from django_hstore.exceptions import HStoreDictException
 from django_hstore.utils import unserialize_references, serialize_references, acquire_reference
@@ -610,6 +610,576 @@ class TestDictionaryField(TestCase):
 
     def test_str(self):
         d = DataBag()
+        self.assertEqual(str(d.data), '{}')
+
+
+class TestSerializedDictionaryField(TestCase):
+    def setUp(self):
+        SerializedDataBag.objects.all().delete()
+        Ref.objects.all().delete()
+        RefsBag.objects.all().delete()
+
+    def _create_bags(self):
+        alpha = SerializedDataBag.objects.create(name='alpha', data={'v': 1, 'v2': '3', 'v3': {'a': 1}})
+        beta = SerializedDataBag.objects.create(name='beta', data={'v': 2, 'v2': [1, '4', 5, {'f': 6}], 'v3': {'a': 2}})
+        return alpha, beta
+
+    def _create_bitfield_bags(self):
+        # create dictionaries with bits as dictionary keys (i.e. bag5 = { 'b0':'1', 'b2':'1'})
+        for i in range(10):
+            SerializedDataBag.objects.create(name='bag%d' % (i,),
+                                   data=dict(('b%d' % (bit,), '1') for bit in range(4) if (1 << bit) & i))
+
+    def test_hstore_dict(self):
+        alpha, beta = self._create_bags()
+        self.assertEqual(alpha.data, {'v': 1, 'v2': '3', 'v3': {'a': 1}})
+        self.assertEqual(beta.data, {'v': 2, 'v2': [1, '4', 5, {'f': 6}], 'v3': {'a': 2}})
+
+    def test_number(self):
+        databag = SerializedDataBag(name='number')
+        databag.data['num'] = 1
+        self.assertEqual(databag.data['num'], 1)
+
+        databag.save()
+        databag = SerializedDataBag.objects.get(name='number')
+        self.assertEqual(databag.data['num'], 1)
+
+        databag = SerializedDataBag(name='number', data={ 'num': 1 })
+        self.assertEqual(databag.data['num'], 1)
+
+    def test_full_clean(self):
+        databag = SerializedDataBag(name='number')
+        databag.data['num'] = 1
+        self.assertEqual(databag.data['num'], 1)
+
+        databag.full_clean()
+        databag.save()
+        databag = SerializedDataBag.objects.get(name='number')
+        self.assertEqual(databag.data['num'], 1)
+
+    def test_list(self):
+        databag = SerializedDataBag.objects.create(name='list', data={ 'list': ['a', 'b', 'c'] })
+        databag = SerializedDataBag.objects.get(name='list')
+        self.assertEqual(databag.data['list'], ['a', 'b', 'c'])
+
+    def test_dictionary(self):
+        databag = SerializedDataBag.objects.create(name='dict', data={ 'dict': {'subkey': 'subvalue'} })
+        databag = SerializedDataBag.objects.get(name='dict')
+        self.assertEqual(databag.data['dict'], {'subkey': 'subvalue'})
+
+        databag.data['dict'] = {'subkey': True, 'list': ['a', 'b', False]}
+        databag.save()
+        self.assertEqual(databag.data['dict'], {'subkey': True, 'list': ['a', 'b', False]})
+
+    def test_boolean(self):
+        databag = SerializedDataBag.objects.create(name='boolean', data={ 'boolean': True })
+        databag = SerializedDataBag.objects.get(name='boolean')
+        self.assertEqual(databag.data['boolean'], True)
+
+    def test_is_pickable(self):
+        m = DefaultsModel()
+        m.save()
+        try:
+            pickle.dumps(m)
+        except TypeError as e:
+            self.fail('pickle of DefaultsModel failed: %s' % e)
+
+    def test_empty_instantiation(self):
+        bag = SerializedDataBag.objects.create(name='bag')
+        self.assertTrue(isinstance(bag.data, dict))
+        self.assertEqual(bag.data, {})
+
+    def test_empty_querying(self):
+        SerializedDataBag.objects.create(name='bag')
+        self.assertTrue(SerializedDataBag.objects.get(data={}))
+        self.assertTrue(SerializedDataBag.objects.filter(data={}))
+        self.assertTrue(SerializedDataBag.objects.filter(data__contains={}))
+
+    def test_nullable_queryinig(self):
+        # backward incompatible change in 1.3.3:
+        # default value of a dictionary field which is can be null will never be None
+        # but always an empty HStoreDict
+        NullableDataBag.objects.create(name='nullable')
+        self.assertFalse(NullableDataBag.objects.filter(data__exact=None))
+        self.assertFalse(NullableDataBag.objects.filter(data__isnull=True))
+        self.assertTrue(NullableDataBag.objects.filter(data__isnull=False))
+
+    def test_nullable_set(self):
+        n = NullableDataBag()
+        n.data['test'] = 'test'
+        self.assertEqual(n.data['test'], 'test')
+
+    def test_nullable_get(self):
+        n = NullableDataBag()
+        self.assertEqual(n.data.get('test', 'test'), 'test')
+        self.assertEqual(n.data.get('test', False), False)
+        self.assertEqual(n.data.get('test'), None)
+
+    def test_nullable_getitem(self):
+        n = NullableDataBag()
+        with self.assertRaises(KeyError):
+            n.data['test']
+
+    def test_null_values(self):
+        null_v = SerializedDataBag.objects.create(name="test", data={"v": None})
+        nonnull_v = SerializedDataBag.objects.create(name="test", data={"v": "item"})
+
+        r = SerializedDataBag.objects.filter(data__isnull={"v": True})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], null_v)
+
+        r = SerializedDataBag.objects.filter(data__isnull={"v": False})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], nonnull_v)
+
+    def test_named_querying(self):
+        alpha, beta = self._create_bags()
+        self.assertEqual(SerializedDataBag.objects.get(name='alpha'), alpha)
+        self.assertEqual(SerializedDataBag.objects.filter(name='beta')[0], beta)
+
+    def test_aggregates(self):
+        self._create_bitfield_bags()
+
+        self.assertEqual(SerializedDataBag.objects.filter(data__contains={'b0': '1'}).aggregate(Count('id'))['id__count'], 5)
+        self.assertEqual(SerializedDataBag.objects.filter(data__contains={'b1': '1'}).aggregate(Count('id'))['id__count'], 4)
+
+    def test_annotations(self):
+        self._create_bitfield_bags()
+
+        self.assertEqual(SerializedDataBag.objects.annotate(num_id=Count('id')).filter(num_id=1)[0].num_id, 1)
+
+    def test_nested_filtering(self):
+        self._create_bitfield_bags()
+
+        # Test cumulative successive filters for both dictionaries and other fields
+        f = SerializedDataBag.objects.all()
+        self.assertEqual(10, f.count())
+        f = f.filter(data__contains={'b0': '1'})
+        self.assertEqual(5, f.count())
+        f = f.filter(data__contains={'b1': '1'})
+        self.assertEqual(2, f.count())
+        f = f.filter(name='bag3')
+        self.assertEqual(1, f.count())
+
+    def test_unicode_processing(self):
+        greets = {
+            u'de': u'Gr\xfc\xdfe, Welt',
+            u'en': u'hello, world',
+            u'es': u'hola, ma\xf1ana',
+            u'he': u'\u05e9\u05dc\u05d5\u05dd, \u05e2\u05d5\u05dc\u05dd',
+            u'jp': u'\u3053\u3093\u306b\u3061\u306f\u3001\u4e16\u754c',
+            u'zh': u'\u4f60\u597d\uff0c\u4e16\u754c',
+        }
+        SerializedDataBag.objects.create(name='multilang', data=greets)
+        self.assertEqual(greets, SerializedDataBag.objects.get(name='multilang').data)
+
+    def test_query_escaping(self):
+        me = self
+
+        def readwrite(s):
+            # try create and query with potentially illegal characters in the field and dictionary key/value
+            o = SerializedDataBag.objects.create(name=s, data={s: s})
+            me.assertEqual(o, SerializedDataBag.objects.get(name=s, data={s: s}))
+        readwrite('\' select')
+        readwrite('% select')
+        readwrite('\\\' select')
+        readwrite('-- select')
+        readwrite('\n select')
+        readwrite('\r select')
+        readwrite('* select')
+
+    def test_replace_full_dictionary(self):
+        SerializedDataBag.objects.create(name='foo', data={'change': 'old value', 'remove': 'baz'})
+
+        replacement = {'change': 'new value', 'added': 'new'}
+        SerializedDataBag.objects.filter(name='foo').update(data=replacement)
+        self.assertEqual(replacement, SerializedDataBag.objects.get(name='foo').data)
+
+    def test_equivalence_querying(self):
+        alpha, beta = self._create_bags()
+        for bag in (alpha, beta):
+            data = {'v': bag.data['v'], 'v2': bag.data['v2'], 'v3': bag.data['v3']}
+            self.assertEqual(SerializedDataBag.objects.get(data=data), bag)
+            r = SerializedDataBag.objects.filter(data=data)
+            self.assertEqual(len(r), 1)
+            self.assertEqual(r[0], bag)
+
+    def test_key_value_subset_querying(self):
+        alpha, beta = self._create_bags()
+        for bag in (alpha, beta):
+            r = SerializedDataBag.objects.filter(data__contains={'v': bag.data['v']})
+            self.assertEqual(len(r), 1)
+            self.assertEqual(r[0], bag)
+            r = SerializedDataBag.objects.filter(data__contains={'v': bag.data['v'], 'v2': bag.data['v2']})
+            self.assertEqual(len(r), 1)
+            self.assertEqual(r[0], bag)
+
+    def test_key_value_gt_querying(self):
+        alpha, beta = self._create_bags()
+        self.assertGreater(beta.data['v'], alpha.data['v'])
+        r = SerializedDataBag.objects.filter(data__gt={'v': alpha.data['v']})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], beta)
+        r = SerializedDataBag.objects.filter(data__gte={'v': alpha.data['v']})
+        self.assertEqual(len(r), 2)
+
+    def test_key_value_gt_casting_number_query(self):
+        alpha = SerializedDataBag.objects.create(name='alpha', data={'v': 10})
+        SerializedDataBag.objects.create(name='alpha', data={'v': 1})
+
+        r = SerializedDataBag.objects.filter(data__gt={'v': 2})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], alpha)
+
+    def test_key_value_contains_casting_date_query(self):
+        date = datetime.date(2014, 9, 28)
+        alpha = SerializedDataBag.objects.create(name='alpha', data={'v': date.isoformat()})
+
+        r = SerializedDataBag.objects.filter(data__contains={'v': date})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], alpha)
+
+    def test_multiple_key_value_gt_querying(self):
+        alpha, beta = self._create_bags()
+        self.assertGreater(beta.data['v'], alpha.data['v'])
+        r = SerializedDataBag.objects.filter(data__gt={'v': alpha.data['v'], 'v3': alpha.data['v3']})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], beta)
+        r = SerializedDataBag.objects.filter(data__gt={'v': alpha.data['v'], 'v3': beta.data['v3']})
+        self.assertEqual(len(r), 0)
+        r = SerializedDataBag.objects.filter(data__gte={'v': alpha.data['v'], 'v3': alpha.data['v3']})
+        self.assertEqual(len(r), 2)
+        r = SerializedDataBag.objects.filter(data__gte={'v': alpha.data['v'], 'v3': beta.data['v3']})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], beta)
+
+    def test_multiple_key_value_lt_querying(self):
+        alpha, beta = self._create_bags()
+        self.assertGreater(beta.data['v'], alpha.data['v'])
+        r = SerializedDataBag.objects.filter(data__lt={'v': beta.data['v'], 'v3': beta.data['v3']})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], alpha)
+        r = SerializedDataBag.objects.filter(data__lt={'v': beta.data['v'], 'v3': alpha.data['v3']})
+        self.assertEqual(len(r), 0)
+        r = SerializedDataBag.objects.filter(data__lte={'v': beta.data['v'], 'v3': beta.data['v3']})
+        self.assertEqual(len(r), 2)
+        r = SerializedDataBag.objects.filter(data__lte={'v': beta.data['v'], 'v3': alpha.data['v3']})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], alpha)
+
+    def test_key_value_lt_querying(self):
+        alpha, beta = self._create_bags()
+        self.assertLess(alpha.data['v'], beta.data['v'])
+        r = SerializedDataBag.objects.filter(data__lt={'v': beta.data['v']})
+        self.assertEqual(len(r), 1)
+        self.assertEqual(r[0], alpha)
+        r = SerializedDataBag.objects.filter(data__lte={'v': beta.data['v']})
+        self.assertEqual(len(r), 2)
+
+    def test_multiple_key_subset_querying(self):
+        alpha, beta = self._create_bags()
+        for keys in (['v'], ['v', 'v2']):
+            self.assertEqual(SerializedDataBag.objects.filter(data__contains=keys).count(), 2)
+        for keys in (['v', 'nv'], ['n1', 'n2']):
+            self.assertEqual(SerializedDataBag.objects.filter(data__contains=keys).count(), 0)
+
+    def test_single_key_querying(self):
+        alpha, beta = self._create_bags()
+        for key in ('v', 'v2'):
+            self.assertEqual(SerializedDataBag.objects.filter(data__contains=[key]).count(), 2)
+        for key in ('n1', 'n2'):
+            self.assertEqual(SerializedDataBag.objects.filter(data__contains=[key]).count(), 0)
+
+    def test_simple_text_icontains_querying(self):
+        alpha, beta = self._create_bags()
+        gamma = SerializedDataBag.objects.create(name='gamma', data={'theKey': 'someverySpecialValue', 'v2': '3'})
+
+        self.assertEqual(SerializedDataBag.objects.filter(data__contains='very').count(), 1)
+        self.assertEqual(SerializedDataBag.objects.filter(data__contains='very')[0].name, 'gamma')
+        self.assertEqual(SerializedDataBag.objects.filter(data__icontains='specialvalue').count(), 1)
+        self.assertEqual(SerializedDataBag.objects.filter(data__icontains='specialvalue')[0].name, 'gamma')
+
+        self.assertEqual(SerializedDataBag.objects.filter(data__contains='the').count(), 1)
+        self.assertEqual(SerializedDataBag.objects.filter(data__contains='the')[0].name, 'gamma')
+        self.assertEqual(SerializedDataBag.objects.filter(data__icontains='eke').count(), 1)
+        self.assertEqual(SerializedDataBag.objects.filter(data__icontains='eke')[0].name, 'gamma')
+
+    def test_containment_lookup(self):
+        alpha, beta = self._create_bags()
+
+        qs = SerializedDataBag.objects.filter(data__contains=1)
+        self.assertEqual(len(qs), 2)
+        self.assertEqual(qs[0], alpha)
+        self.assertEqual(qs[1], beta)
+
+        qs = SerializedDataBag.objects.filter(data__icontains=2)
+        self.assertEqual(len(qs), 2)
+        self.assertEqual(list(qs), [alpha, beta])
+
+        qs = SerializedDataBag.objects.filter(data__contains='3')
+        self.assertEqual(len(qs), 2)
+        self.assertEqual(qs[0], alpha)
+        self.assertEqual(qs[1], beta)
+
+        qs = SerializedDataBag.objects.filter(data__contains='4')
+        self.assertEqual(len(qs), 1)
+        self.assertEqual(qs[0], beta)
+
+        # Multiple filters
+        qs = SerializedDataBag.objects.filter(data__contains='4').filter(data__contains=5)
+        self.assertEqual(len(qs), 1)
+        self.assertEqual(qs[0], beta)
+
+        qs = SerializedDataBag.objects.filter(data__contains=1).filter(data__contains='4')
+        self.assertEqual(len(qs), 1)
+        self.assertEqual(qs[0], beta)
+
+        # Contains value in nested dict
+        qs = SerializedDataBag.objects.filter(data__contains=6)
+        self.assertEqual(len(qs), 1)
+
+    def test_invalid_comparison_lookup_values(self):
+        alpha, beta = self._create_bags()
+        with self.assertRaises(ValueError):
+            SerializedDataBag.objects.filter(data__lt=[1,2])[0]
+        with self.assertRaises(ValueError):
+            SerializedDataBag.objects.filter(data__lt=99)[0]
+        with self.assertRaises(ValueError):
+            SerializedDataBag.objects.filter(data__lte=[1,2])[0]
+        with self.assertRaises(ValueError):
+            SerializedDataBag.objects.filter(data__lte=99)[0]
+        with self.assertRaises(ValueError):
+            SerializedDataBag.objects.filter(data__gt=[1,2])[0]
+        with self.assertRaises(ValueError):
+            SerializedDataBag.objects.filter(data__gt=99)[0]
+        with self.assertRaises(ValueError):
+            SerializedDataBag.objects.filter(data__gte=[1,2])[0]
+        with self.assertRaises(ValueError):
+            SerializedDataBag.objects.filter(data__gte=99)[0]
+
+    def test_hkeys(self):
+        alpha, beta = self._create_bags()
+        self.assertEqual(SerializedDataBag.objects.hkeys(id=alpha.id, attr='data'), ['v', 'v2', 'v3'])
+        self.assertEqual(SerializedDataBag.objects.hkeys(id=beta.id, attr='data'), ['v', 'v2', 'v3'])
+
+    def test_hpeek(self):
+        alpha, beta = self._create_bags()
+        self.assertEqual(SerializedDataBag.objects.hpeek(id=alpha.id, attr='data', key='v'), 1)
+        self.assertEqual(SerializedDataBag.objects.filter(id=alpha.id).hpeek(attr='data', key='v'), 1)
+        self.assertEqual(SerializedDataBag.objects.hpeek(id=alpha.id, attr='data', key='invalid'), None)
+
+    def test_hremove(self):
+        alpha, beta = self._create_bags()
+        self.assertEqual(SerializedDataBag.objects.get(name='alpha').data, alpha.data)
+        SerializedDataBag.objects.filter(name='alpha').hremove('data', 'v2')
+        self.assertEqual(SerializedDataBag.objects.get(name='alpha').data, {'v': 1, 'v3': {'a': 1}})
+
+        self.assertEqual(SerializedDataBag.objects.get(name='beta').data, beta.data)
+        SerializedDataBag.objects.filter(name='beta').hremove('data', ['v', 'v2', 'v3'])
+        self.assertEqual(SerializedDataBag.objects.get(name='beta').data, {})
+
+    def test_hslice(self):
+        alpha, beta = self._create_bags()
+        self.assertEqual(SerializedDataBag.objects.hslice(id=alpha.id, attr='data', keys=['v']), {'v': 1})
+        self.assertEqual(SerializedDataBag.objects.filter(id=alpha.id).hslice(attr='data', keys=['v']), {'v': 1})
+        self.assertEqual(SerializedDataBag.objects.hslice(id=alpha.id, attr='data', keys=['ggg']), {})
+
+    def test_hupdate(self):
+        alpha, beta = self._create_bags()
+        self.assertEqual(SerializedDataBag.objects.get(name='alpha').data, alpha.data)
+        SerializedDataBag.objects.filter(name='alpha').hupdate('data', {'v2': '10', 'v3': {'a':'20'}})
+        self.assertEqual(SerializedDataBag.objects.get(name='alpha').data, {'v': 1, 'v2': '10', 'v3': {'a':'20'}})
+
+    def test_default(self):
+        m = DefaultsModel()
+        m.save()
+
+    def test_bad_default(self):
+        m = BadDefaultsModel()
+        try:
+            m.save()
+        except IntegrityError:
+            transaction.rollback()
+        else:
+            self.assertTrue(False)
+
+    def test_hstoredictionaryexception(self):
+        # ok
+        HStoreDict({})
+
+        # json object string allowed
+        HStoreDict('{}')
+
+        # None is ok, will be converted to empty dict
+        HStoreDict(None)
+        HStoreDict()
+
+        # non-json string not allowed
+        with self.assertRaises(HStoreDictException):
+            HStoreDict('wrong')
+
+        # list not allowed
+        with self.assertRaises(HStoreDictException):
+            HStoreDict(['wrong'])
+
+        # json array string representation not allowed
+        with self.assertRaises(HStoreDictException):
+            HStoreDict('["wrong"]')
+
+        # number not allowed
+        with self.assertRaises(HStoreDictException):
+            HStoreDict(3)
+
+    def test_hstoredictionary_unicoce_vs_str(self):
+        d = HStoreDict({ 'test': 'test' })
+        self.assertEqual(d.__str__(), d.__unicode__())
+
+    def test_hstore_model_field_validation(self):
+        d = SerializedDataBag()
+
+        with self.assertRaises(ValidationError):
+            d.full_clean()
+
+        d.data = 'test'
+
+        with self.assertRaises(ValidationError):
+            d.full_clean()
+
+        d.data = '["test"]'
+
+        with self.assertRaises(ValidationError):
+            d.full_clean()
+
+        d.data = ["test"]
+
+        with self.assertRaises(ValidationError):
+            d.full_clean()
+
+        d.data = {
+            'a': 1,
+            'b': 2.2,
+            'c': ['a', 'b'],
+            'd': { 'test': 'test' }
+        }
+
+        with self.assertRaises(ValidationError):
+            d.full_clean()
+
+    def test_admin_widget(self):
+        alpha, beta = self._create_bags()
+
+        # create admin user
+        admin = User.objects.create(username='admin', password='tester', is_staff=True, is_superuser=True, is_active=True)
+        admin.set_password('tester')
+        admin.save()
+        # login as admin
+        self.client.login(username='admin', password='tester')
+
+        # access admin change form page
+        url = reverse('admin:django_hstore_tests_serializeddatabag_change', args=[alpha.id])
+        response = self.client.get(url)
+        # ensure textarea with id="id_data" is there
+        self.assertContains(response, 'textarea')
+        self.assertContains(response, 'id_data')
+
+    def test_dictionary_default_admin_widget(self):
+        class HForm(forms.ModelForm):
+            class Meta:
+                model = SerializedDataBag
+                exclude = []
+
+        form = HForm()
+        self.assertEqual(form.fields['data'].widget.__class__, SerializedDictionaryFieldWidget)
+
+    def test_dictionary_custom_admin_widget(self):
+        class CustomWidget(forms.Widget):
+            pass
+
+        class HForm(forms.ModelForm):
+            class Meta:
+                model = SerializedDataBag
+                widgets = {'data': CustomWidget}
+                exclude = []
+
+        form = HForm()
+        self.assertEqual(form.fields['data'].widget.__class__, CustomWidget)
+
+    def test_references_default_admin_widget(self):
+        class HForm(forms.ModelForm):
+            class Meta:
+                model = RefsBag
+                exclude = []
+
+        form = HForm()
+        self.assertEqual(form.fields['refs'].widget.__class__, ReferencesFieldWidget)
+
+    def test_references_custom_admin_widget(self):
+        class CustomWidget(forms.Widget):
+            pass
+
+        class HForm(forms.ModelForm):
+            class Meta:
+                model = RefsBag
+                widgets = {'refs': CustomWidget}
+                exclude = []
+
+        form = HForm()
+        self.assertEqual(form.fields['refs'].widget.__class__, CustomWidget)
+
+    def test_get_version(self):
+        get_version()
+
+    def test_unique_together(self):
+        d = UniqueTogetherDataBag()
+        d.name = 'test'
+        d.data = { 'test': 'test '}
+        d.full_clean()
+        d.save()
+
+        d = UniqueTogetherDataBag()
+        d.name = 'test'
+        d.data = { 'test': 'test '}
+        with self.assertRaises(ValidationError):
+            d.full_clean()
+
+    def test_properties_hstore(self):
+        """
+        Make sure the hstore field does what it is supposed to.
+        """
+        from django_hstore.fields import HStoreDict
+
+        instance = SerializedDataBag()
+        test_props = {'foo':'bar', 'size': '3'}
+
+        instance.name = "foo"
+        instance.data = test_props
+        instance.save()
+
+        self.assertEqual(type(instance.data), dict)
+        self.assertEqual(instance.data, test_props)
+        instance = SerializedDataBag.objects.get(pk=instance.pk)
+
+        self.assertEqual(type(instance.data), dict)
+
+        self.assertEqual(instance.data, test_props)
+        self.assertEqual(instance.data['size'], '3')
+        self.assertIn('foo', instance.data)
+
+    def test_unicode(self):
+        i = SerializedDataBag()
+        i.data['key'] = 'è'
+        i.save()
+
+        i.data['key'] = u'è'
+        i.save()
+
+    def test_get_default(self):
+        d = HStoreDict()
+        self.assertIsNone(d.get('none_key', None))
+        self.assertIsNone(d.get('none_key'))
+
+    def test_str(self):
+        d = SerializedDataBag()
         self.assertEqual(str(d.data), '{}')
 
 


### PR DESCRIPTION
Add new hstore field type, `SerializedDictionaryField`.  This field accepts optional `serializer` and `deserializer` arguments (defaulting to `json.dumps` and `json.loads`, respectively).  The field returns a `dict` object (not `HStoreDict`), and runs all data through the `serializer` before insertions into the DB (along within runing all data through the `deserializer` when retrieving from the DB).  This allows data placed into the field to maintain their type (provided that the data is compatible with the serializer and that the serializer only outputs `str` data).  Additionally, by defining their own serializer functions, a user can easily put in custom logic to handle non-standard datatypes (for instance, if one was interested in serializing a custom class to a specific format).

The implementation is pretty straightforward:

``` python
# models.py
class SerializedExample(models.Model):
    name = models.CharField(max_length=32)
    data = hstore.SerializedDictionaryField()
    objects = hstore.HStoreManager()

>>> obj = SerializedExample.objects.create(
...   name="A Serializable Field!", 
...   data={
...     'str': 'A string',
...     'int': 1234,
...     'float': 3.141,
...     'bool': True,
...     'list': [0, 'one', [2.0, 2.1]],
...     'dict': {
...       'a': 1,
...       'b': 'two',
...       'c': ['three']
...     }
...   }
... )

>>> obj.data
{'int': 1234, 'float': 3.141, 'list': [0, 'one', [2.0, 2.1]], 'bool': True, 'str': 'A string', 'dict': {'a': 1, 'c': ['three'], 'b': 'two'}
```

This feature made other features not possible for the `SerializedDictionaryField`, such as subsetting against a list of values:

``` python
# Expression will be interpreted as subsetting by key/value mapping, not subsetting against a list of values.
Something.objects.filter(data__contains={'a': ['1', '2']})
```

Other non-supported features: maintaining type on `Decimal` or `long`.

I do believe that this optional functionality could be rolled into the standard `HStoreField`, but for the sake of clarity it was kept in it's own field.  Also for the sake of clarity, unsupported features were left in the `TestSerializedDictionaryField` class as commented-out text (this should be removed before the pull request is approved).

This pull request is in response to [this thread](https://groups.google.com/forum/#!topic/django-hstore/AqG6seEEwx0) on the django-hstore group.
