### PR TITLE
handle none

### DIFF
--- a/django_hstore/virtual.py
+++ b/django_hstore/virtual.py
@@ -55,6 +55,9 @@ class HStoreVirtualMixin(object):
         set value on hstore dictionary
         """
         hstore_dictionary = getattr(instance, self.hstore_field_name)
+        if hstore_dictionary is None:
+            hstore_dictionary = {}
+            setattr(instance, self.hstore_field_name, hstore_dictionary)
         hstore_dictionary[self.name] = value
 
     # end descriptor methods

--- a/django_hstore/virtual.py
+++ b/django_hstore/virtual.py
@@ -45,8 +45,10 @@ class HStoreVirtualMixin(object):
         """
         if instance is None:
             raise AttributeError('Can only be accessed via instance')
-
-        return getattr(instance, self.hstore_field_name).get(self.name, self.default)
+        field = getattr(instance, self.hstore_field_name)
+        if not field:
+            return self.default
+        return field.get(self.name, self.default)
 
     def __set__(self, instance, value):
         """


### PR DESCRIPTION
My migrations contains:

```python
        migrations.AddField(
            model_name='author',
            name='data',
            field=django_hstore.fields.DictionaryField(null=True, editable=False),
            preserve_default=True,
        ),
```
Not sure if this is the proper fix, or if I should create the field non null with default value of empty dictionaty.

I think I followed the instructions.