### PR TITLE
for some reason the second create() fails (using model with slug PK)

### DIFF
--- a/tests/django_hstore_tests/tests.py
+++ b/tests/django_hstore_tests/tests.py
@@ -659,6 +659,14 @@ class TestSerializedDictionaryField(TestCase):
         databag.save()
         SerializedDataBagNoID.objects.get(slug='123')
 
+    def test_create_directly(self):
+        databag = SerializedDataBag.objects.create(
+            name='abc', data={'num': 1}
+        )
+        databagnoid = SerializedDataBagNoID.objects.create(
+            slug='123', name='abc', data={'num': 1}
+        )
+
     def test_full_clean(self):
         databag = SerializedDataBag(name='number')
         databag.data['num'] = 1


### PR DESCRIPTION
Opened to expose issue (#111)
Not sure what's going on here; the `create()` call with a model that uses a slug for a primary key has issues with the dictionary... 