### PR TITLE
Update forms.py: Hstore validate - value not assignment

### DIFF
--- a/django_hstore/forms.py
+++ b/django_hstore/forms.py
@@ -17,7 +17,7 @@ from . import utils
 def validate_hstore(value, is_serialized=False):
     """ HSTORE validation. """
     # if empty
-    if value == '' or value == 'null':
+    if value is None or value == '' or value == 'null':
         value = '{}'
 
     # ensure valid JSON


### PR DESCRIPTION
When define filter class for rest framework:
class DictionaryHstoreFilter(django_filters.Filter):
field_class = forms.DictionaryField

viewset forms is not validated.

When change in forms.py (in def validate_hstore - line 19):
if value == '' or value == 'null':

to...
if value is None or value == '' or value == 'null':
forms is validate work!

Thank you.
