### PR TITLE
Fix issue#93 - hstore connection registration bug

### DIFF
--- a/django_hstore/apps.py
+++ b/django_hstore/apps.py
@@ -11,6 +11,7 @@ except ImportError:  # pragma no cover
     AppConfig = object
 
 HSTORE_REGISTER_GLOBALLY = getattr(settings, "DJANGO_HSTORE_ADAPTER_REGISTRATION", "global") == "global"
+CONNECTION_CREATED_SIGNAL_WEAKREF = bool(getattr(settings, "DJANGO_HSTORE_ADAPTER_SIGNAL_WEAKREF", False))
 
 # This allows users that introduce hstore into an existing
 # environment to disable global registration of the hstore adapter
@@ -88,7 +89,7 @@ class HStoreConfig(AppConfig):
 
     def ready(self):
         connection_created.connect(connection_handler,
-                                   weak=False,
+                                   weak=CONNECTION_CREATED_SIGNAL_WEAKREF,
                                    dispatch_uid="_connection_create_handler")
 
 if django.get_version() < '1.7':

--- a/django_hstore/apps.py
+++ b/django_hstore/apps.py
@@ -88,6 +88,7 @@ class HStoreConfig(AppConfig):
 
     def ready(self):
         connection_created.connect(connection_handler,
+                                   weak=False,
                                    dispatch_uid="_connection_create_handler")
 
 if django.get_version() < '1.7':


### PR DESCRIPTION
This should address issue #93.
I've found the problem and solution. My reproduction was different though.
Django signals are used to observe every new connection and call psycopg2's register_hstore function on it.
Django signals will, by default, store references to the receiver functions as weakrefs.
In a low memory situation these can go away and future connections are not registered to use hstore features.
The fix is very simple - pass weak=False when connecting the signal.