### PR TITLE
Bandaid fix to avoid ImportError in Django19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 
 services:
   - postgresql
@@ -10,7 +11,8 @@ python:
   - "2.6"
 
 env:
-  - DJANGO="django==1.8.2"
+  - DJANGO="django==1.9b1"
+  - DJANGO="django==1.8.5"
   - DJANGO="django==1.7.7"
   - DJANGO="django==1.6.11"
 
@@ -19,7 +21,14 @@ matrix:
     - python: "2.6"
       env: DJANGO="django==1.7.7"
     - python: "2.6"
-      env: DJANGO="django==1.8.2"
+      env: DJANGO="django==1.8.5"
+    - python: "2.6"
+      env: DJANGO="django==1.9b1"
+    - python: "3.3"
+      env: DJANGO="django==1.9b1"
+
+  allow_failures:
+    - env: DJANGO="django==1.9b1"
 
 branches:
   only:

--- a/django_hstore/query.py
+++ b/django_hstore/query.py
@@ -8,7 +8,11 @@ from django.db.models.sql.constants import SINGLE
 from django.db.models.sql.datastructures import EmptyResultSet
 from django.db.models.sql.query import Query
 from django.db.models.sql.subqueries import UpdateQuery
-from django.db.models.sql.where import EmptyShortCircuit, WhereNode
+from django.db.models.sql.where import WhereNode
+try:
+    from django.db.models.sql.where import EmptyShortCircuit
+except ImportError:
+    EmptyShortCircuit = Exception
 from django.utils import six
 
 from django_hstore.apps import GEODJANGO_INSTALLED


### PR DESCRIPTION
EmptyShortCircuit was removed from django here:
django/django@4d3470e

The whole HStoreWhereNode class needs to be updated (see #135), however this fix provides a temporary remedy to allow hstore to function in django19.