### PR TITLE
Regression in 1.4.1

### DIFF
--- a/django_hstore/dict.py
+++ b/django_hstore/dict.py
@@ -15,6 +15,13 @@ __all__ = [
 ]
 
 
+class DecimalEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Decimal):
+            return float(obj)
+        return json.JSONEncoder.default(self, obj)
+
+
 class HStoreDict(UnicodeMixin, dict):
     """
     A dictionary subclass which implements hstore support.
@@ -120,7 +127,7 @@ class HStoreDict(UnicodeMixin, dict):
             elif isinstance(value, six.integer_types + (float, Decimal)):
                 return force_text(value)
             elif isinstance(value, (list, dict)):
-                return force_text(json.dumps(value))
+                return force_text(json.dumps(value, cls=DecimalEncoder))
             else:
                 return value
         else:

--- a/tests/django_hstore_tests/tests/test_dictionary_field.py
+++ b/tests/django_hstore_tests/tests/test_dictionary_field.py
@@ -597,6 +597,18 @@ class TestDictionaryField(TestCase):
         d = DataBag()
         self.assertEqual(str(d.data), '{}')
 
+    def test_array_with_decimal(self):
+        instance = DataBag(name="decimal")
+        array_decimal = [Decimal('1.01')]
+        array_dumped = '[1.01]'
+        instance.data['arr_dec'] = array_decimal
+
+        self.assertEqual(instance.data['arr_dec'], array_dumped)
+        instance.save()
+
+        instance = DataBag.objects.get(pk=instance.pk)
+        self.assertEqual(instance.data['arr_dec'], array_dumped)
+
     def test_native_contains(self):
         d = DataBag()
         d.name = "A bag of data"


### PR DESCRIPTION
This PR addressed to #144.

Extending JSONEncoder:
https://docs.python.org/2/library/json.html
https://docs.python.org/3.6/library/json.html

Yeah, I understand that Decimal and float **are not** the same, but we have a trade-offs in this case: 
- explicitly require `simplejson` (to allow consistent behaviour on different setups and test passing)
- more low-level `json.JSONEncoder` redefinition, but it may breaks on future changes. Also, I'm not looking into that and don't know, how it should be implemented
- or convert Decimals to float and leave some representation problems with numbers like `Decimal('3.93999999999999999')`. After `json.dumps` it would look like `3.94`.

I've chosen third.

Also I cleaned some old code, that I've met. I'll be glad to listen any ideas about implementation and realization, if you have!