### PR TITLE
adjusted img links for Django 1.9

### DIFF
--- a/django_hstore/templates/hstore_default_widget.html
+++ b/django_hstore/templates/hstore_default_widget.html
@@ -10,7 +10,7 @@
                    placeholder="{% trans 'value' %}">
             &nbsp;&nbsp;
             <a href="#" class="remove-row" title="{% trans 'remove row' %}">
-                <img src="{{ STATIC_URL }}admin/img/icon_deletelink.gif" width="10" height="10">
+                <img src="{{ STATIC_URL }}admin/img/{% if use_svg %}icon-deletelink.svg{% else %}icon_deletelink.gif{% endif %}" width="10" height="10">
             </a>
         </div>
     </div>
@@ -50,12 +50,12 @@
 
         <div class="form-row">
             <a href="#" class="hs-add-row" title="{% trans 'Add another row' %}">
-                <img src="{{ STATIC_URL }}admin/img/icon_addlink.gif" width="10" height="10" alt="{% trans 'Add Another' %}">
+                <img src="{{ STATIC_URL }}admin/img/{% if use_svg %}icon-addlink.svg{% else %}icon_addlink.gif{% endif %}" width="10" height="10" alt="{% trans 'Add Another' %}">
                 {% trans "Add row" %}
             </a>
 
             <a href="#" class="hstore-toggle-txtarea" title="{% trans 'toggle textarea' %}" style="float:right">
-                <img src="{{ STATIC_URL }}admin/img/icon_changelink.gif" width="10" height="10" alt="{% trans 'toggle textarea' %}">
+                <img src="{{ STATIC_URL }}admin/img/{% if use_svg %}icon-changelink.svg{% else %}icon_changelink.gif{% endif %}" width="10" height="10" alt="{% trans 'toggle textarea' %}">
                 {% trans 'toggle textarea' %}
             </a>
         </div>

--- a/django_hstore/widgets.py
+++ b/django_hstore/widgets.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals, absolute_import
 
-from django import forms
+from django import forms, get_version
 from django.contrib.admin.widgets import AdminTextareaWidget
 from django.contrib.admin.templatetags.admin_static import static
 from django.template import Context
@@ -41,7 +41,9 @@ class BaseAdminHStoreWidget(AdminTextareaWidget):
         html = super(BaseAdminHStoreWidget, self).render(name, value, attrs)
 
         # prepare template context
+        use_svg = get_version() >= '1.9'
         template_context = Context({
+            'use_svg': use_svg,
             'field_name': name,
             'STATIC_URL': settings.STATIC_URL
         })


### PR DESCRIPTION
Fix for issue #148. Maybe it's a problem that it would break links for older Django versions?