### PR TITLE
Django110 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
   - "2.7"
 
 env:
+  - DJANGO="django==1.10b1"
   - DJANGO="django>=1.9,<1.10"
   - DJANGO="django>=1.8,<1.9"
   - DJANGO="django>=1.7,<1.8"
@@ -18,6 +19,8 @@ matrix:
   exclude:
     - python: "3.3"
       env: DJANGO="django>=1.9,<1.10"
+    - python: "3.3"
+      env: DJANGO="django==1.10b1"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,12 @@ services:
   - postgresql
 
 python:
-  - "3.4"
-  - "3.3"
   - "2.7"
+  - "3.3"
+  - "3.4"
 
 env:
-  - DJANGO="django==1.10,<1.11"
+  - DJANGO="django>=1.10,<1.11"
   - DJANGO="django>=1.9,<1.10"
   - DJANGO="django>=1.8,<1.9"
   - DJANGO="django>=1.7,<1.8"
@@ -20,7 +20,12 @@ matrix:
     - python: "3.3"
       env: DJANGO="django>=1.9,<1.10"
     - python: "3.3"
-      env: DJANGO="django==1.10,<1.11"
+      env: DJANGO="django>=1.10,<1.11"
+  allow_failures:
+    - python: "2.7"
+      env: DJANGO="django>=1.10,<1.11"
+    - python: "3.4"
+      env: DJANGO="django>=1.10,<1.11"
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ python:
   - "2.7"
 
 env:
-  - DJANGO="django==1.10b1"
+  - DJANGO="django==1.10,<1.11"
   - DJANGO="django>=1.9,<1.10"
   - DJANGO="django>=1.8,<1.9"
   - DJANGO="django>=1.7,<1.8"
@@ -20,7 +20,7 @@ matrix:
     - python: "3.3"
       env: DJANGO="django>=1.9,<1.10"
     - python: "3.3"
-      env: DJANGO="django==1.10b1"
+      env: DJANGO="django==1.10,<1.11"
 
 branches:
   only:

--- a/django_hstore/descriptors.py
+++ b/django_hstore/descriptors.py
@@ -1,6 +1,4 @@
-from django.db import models
 from .dict import HStoreDict, HStoreReferenceDict
-
 
 __all__ = [
     'HStoreDescriptor',
@@ -9,7 +7,23 @@ __all__ = [
 ]
 
 
-class HStoreDescriptor(models.fields.subclassing.Creator):
+class Creator(object):
+    """
+    A placeholder class that provides a way to set the attribute on the model.
+    """
+    def __init__(self, field):
+        self.field = field
+
+    def __get__(self, obj, type=None):
+        if obj is None:
+            return self
+        return obj.__dict__[self.field.name]
+
+    def __set__(self, obj, value):
+        obj.__dict__[self.field.name] = self.field.to_python(value)
+
+
+class HStoreDescriptor(Creator):
     _DictClass = HStoreDict
 
     def __init__(self, *args, **kwargs):
@@ -25,7 +39,7 @@ class HStoreDescriptor(models.fields.subclassing.Creator):
         obj.__dict__[self.field.name] = value
 
 
-class SerializedDictDescriptor(models.fields.subclassing.Creator):
+class SerializedDictDescriptor(Creator):
     _DictClass = dict
 
     def __set__(self, obj, value):

--- a/django_hstore/fields.py
+++ b/django_hstore/fields.py
@@ -1,17 +1,17 @@
-from __future__ import unicode_literals, absolute_import
-import json
+from __future__ import absolute_import, unicode_literals
+
 import datetime
-from pkg_resources import parse_version
+import json
 
+import django
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
 from django.utils import six
-from django import get_version
+from django.utils.translation import ugettext_lazy as _
 
+from . import forms, utils
 from .descriptors import HStoreDescriptor, HStoreReferenceDescriptor, SerializedDictDescriptor
 from .dict import HStoreDict, HStoreReferenceDict
 from .virtual import create_hstore_virtual_field
-from . import forms, utils
 
 
 class HStoreField(models.Field):
@@ -72,7 +72,7 @@ class HStoreField(models.Field):
         return name, args, kwargs
 
 
-if parse_version(get_version()) >= parse_version('1.7'):
+if django.VERSION >= (1, 7):
     from .lookups import (HStoreGreaterThan, HStoreGreaterThanOrEqual, HStoreLessThan,
                           HStoreLessThanOrEqual, HStoreContains, HStoreIContains, HStoreIsNull)
 
@@ -195,7 +195,7 @@ class DictionaryField(HStoreField):
                 delattr(cls, field_name)
             delattr(cls, '_hstore_virtual_fields')
         # django >= 1.8
-        if parse_version(get_version()[0:3]) >= parse_version('1.8'):
+        if django.VERSION >= (1, 8):
             # remove  all hstore virtual fields from meta
             hstore_fields = []
             # get all the existing hstore virtual fields
@@ -210,7 +210,7 @@ class DictionaryField(HStoreField):
             # cls._meta.fields.__class__ == ImmutableList
             cls._meta.fields = cls._meta.fields.__class__(fields)
         # django <= 1.7
-        # TODO: will removed when django 1.7 will be deprecated
+        # TODO: Remove this when django 1.7 is no longer supported.
         else:
             # remove  all hstore virtual fields from meta
             for meta_fields in ['fields', 'local_fields', 'virtual_fields']:

--- a/django_hstore/widgets.py
+++ b/django_hstore/widgets.py
@@ -1,14 +1,13 @@
-from __future__ import unicode_literals, absolute_import
-from pkg_resources import parse_version
+from __future__ import absolute_import, unicode_literals
 
-from django import forms, get_version
-from django.contrib.admin.widgets import AdminTextareaWidget
+import django
+from django import forms
+from django.conf import settings
 from django.contrib.admin.templatetags.admin_static import static
+from django.contrib.admin.widgets import AdminTextareaWidget
 from django.template import Context
 from django.template.loader import get_template
 from django.utils.safestring import mark_safe
-from django.conf import settings
-
 
 __all__ = [
     'AdminHStoreWidget'
@@ -45,7 +44,7 @@ class BaseAdminHStoreWidget(AdminTextareaWidget):
         template_context = Context({
             'field_name': name,
             'STATIC_URL': settings.STATIC_URL,
-            'use_svg': parse_version(get_version()) >= parse_version('1.9'),  # use svg icons if django >= 1.9
+            'use_svg': django.VERSION >= (1, 9),  # use svg icons if django >= 1.9
         })
         # get template object
         template = get_template('hstore_%s_widget.html' % self.admin_style)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,12 @@
 [bdist_wheel]
 universal=1
+
+[isort]
+known_django = django
+sections = FUTURE,STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,LOCALFOLDER
+default_section = THIRDPARTY
+known_standard_library = requests
+known_first_party = django_hstore
+multi_line_output = 3
+line_length = 100
+indent = 4

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,10 +3,11 @@ universal=1
 
 [isort]
 known_django = django
-sections = FUTURE,STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,LOCALFOLDER
+sections = FUTURE,STDLIB,THIRDPARTY,DJANGO,FIRSTPARTY,TESTS,LOCALFOLDER
 default_section = THIRDPARTY
 known_standard_library = requests
 known_first_party = django_hstore
+known_tests = django_hstore_tests
 multi_line_output = 3
 line_length = 100
 indent = 4

--- a/tests/django_hstore_tests/admin.py
+++ b/tests/django_hstore_tests/admin.py
@@ -1,6 +1,6 @@
-from pkg_resources import parse_version
+import django
 from django.contrib import admin
-from django import get_version
+
 from .models import *  # noqa
 
 
@@ -27,7 +27,7 @@ admin.site.register(DefaultsModel, DefaultsModelAdmin)
 admin.site.register(RefsBag, RefsBagAdmin)
 
 
-if parse_version(get_version()) >= parse_version('1.6'):
+if django.VERSION >= (1, 6):
     class SchemaDataBagAdmin(admin.ModelAdmin):
         list_display = ['name']
 

--- a/tests/django_hstore_tests/models.py
+++ b/tests/django_hstore_tests/models.py
@@ -1,10 +1,8 @@
-from pkg_resources import parse_version
+import django
 from django.db import models
-from django import get_version
 
 from django_hstore import hstore
 from django_hstore.apps import GEODJANGO_INSTALLED
-
 
 __all__ = [
     'Ref',
@@ -92,7 +90,7 @@ class UniqueTogetherDataBag(HStoreModel):
     class Meta:
         unique_together = ('name', 'data')
 
-if parse_version(get_version()[0:3]) >= parse_version('1.6'):
+if django.VERSION >= (1, 6):
     class SchemaDataBag(HStoreModel):
         name = models.CharField(max_length=32)
         data = hstore.DictionaryField(schema=[

--- a/tests/django_hstore_tests/tests/test_dictionary_field.py
+++ b/tests/django_hstore_tests/tests/test_dictionary_field.py
@@ -1,33 +1,35 @@
 # -*- coding: utf-8 -*-
-import sys
+import datetime
 import json
 import pickle
+import sys
 from decimal import Decimal
-import datetime
 
 from django import VERSION as DJANGO_VERSION
 from django import forms
+from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.core.urlresolvers import reverse
 from django.db import transaction
 from django.db.models.aggregates import Count
 from django.db.utils import IntegrityError
-from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
-from django.contrib.auth.models import User
-from django.utils.encoding import force_text
 from django.test import TestCase
+from django.utils.encoding import force_text
 
 from django_hstore import get_version
-from django_hstore.forms import DictionaryFieldWidget
-from django_hstore.fields import HStoreDict
 from django_hstore.exceptions import HStoreDictException
+from django_hstore.fields import HStoreDict
+from django_hstore.forms import DictionaryFieldWidget
 from django_hstore.utils import get_cast_for_param
 
-from django_hstore_tests.models import (DataBag,
-                                        DefaultsModel,
-                                        NullableDataBag,
-                                        BadDefaultsModel,
-                                        UniqueTogetherDataBag,
-                                        NumberedDataBag)
+from django_hstore_tests.models import (
+    BadDefaultsModel,
+    DataBag,
+    DefaultsModel,
+    NullableDataBag,
+    NumberedDataBag,
+    UniqueTogetherDataBag
+)
 
 
 class TestDictionaryField(TestCase):
@@ -64,7 +66,7 @@ class TestDictionaryField(TestCase):
 
     def test_long(self):
         if sys.version < '3':
-            l = long(100000000000)
+            l = long(100000000000)  # noqa
             databag = DataBag(name='long')
             databag.data['long'] = l
             self.assertEqual(databag.data['long'], force_text(l))
@@ -172,7 +174,6 @@ class TestDictionaryField(TestCase):
 
     def test_aggregates(self):
         self._create_bitfield_bags()
-
         self.assertEqual(DataBag.objects.filter(data__contains={'b0': '1'}).aggregate(Count('id'))['id__count'], 5)
         self.assertEqual(DataBag.objects.filter(data__contains={'b1': '1'}).aggregate(Count('id'))['id__count'], 4)
 

--- a/tests/django_hstore_tests/tests/test_not_transactional.py
+++ b/tests/django_hstore_tests/tests/test_not_transactional.py
@@ -1,5 +1,5 @@
 from django import VERSION as DJANGO_VERSION
-from django.db import transaction, connection
+from django.db import connection, transaction
 from django.test import SimpleTestCase
 
 from django_hstore.fields import HStoreDict

--- a/tests/django_hstore_tests/tests/test_reference_field.py
+++ b/tests/django_hstore_tests/tests/test_reference_field.py
@@ -1,12 +1,12 @@
-from django.core.urlresolvers import reverse
-from django.contrib.auth.models import User
-from django.test import TestCase
 from django import forms
+from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.test import TestCase
 
 from django_hstore.forms import ReferencesFieldWidget
-from django_hstore.utils import unserialize_references, serialize_references, acquire_reference
+from django_hstore.utils import acquire_reference, serialize_references, unserialize_references
 
-from django_hstore_tests.models import Ref, RefsBag, NullableRefsBag
+from django_hstore_tests.models import NullableRefsBag, Ref, RefsBag
 
 
 class TestReferencesField(TestCase):

--- a/tests/django_hstore_tests/tests/test_schema_mode.py
+++ b/tests/django_hstore_tests/tests/test_schema_mode.py
@@ -3,8 +3,6 @@ import os
 import shutil
 import sys
 
-from django_hstore_tests.models import NullSchemaDataBag, SchemaDataBag
-
 import django
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
@@ -15,6 +13,8 @@ from django.test import TestCase
 
 from django_hstore import hstore
 from django_hstore.virtual import create_hstore_virtual_field
+
+from django_hstore_tests.models import NullSchemaDataBag, SchemaDataBag
 
 if sys.version_info[0] >= 3:
     from io import StringIO

--- a/tests/django_hstore_tests/tests/test_schema_mode.py
+++ b/tests/django_hstore_tests/tests/test_schema_mode.py
@@ -1,25 +1,25 @@
 # -*- coding: utf-8 -*-
 import os
-import sys
 import shutil
+import sys
 
-if sys.version_info[0] >= 3:
-    from io import StringIO
-else:
-    from StringIO import StringIO
+from django_hstore_tests.models import NullSchemaDataBag, SchemaDataBag
 
-from django import VERSION as DJANGO_VERSION
-from django.db import models
-from django.core.exceptions import ValidationError
-from django.core.urlresolvers import reverse
-from django.core.management import call_command
+import django
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
+from django.core.management import call_command
+from django.core.urlresolvers import reverse
+from django.db import models
 from django.test import TestCase
 
 from django_hstore import hstore
 from django_hstore.virtual import create_hstore_virtual_field
 
-from django_hstore_tests.models import SchemaDataBag, NullSchemaDataBag
+if sys.version_info[0] >= 3:
+    from io import StringIO
+else:
+    from StringIO import StringIO
 
 
 MIGRATION_PATH = '{0}/../{1}'.format(os.path.dirname(__file__), 'migrations')
@@ -287,7 +287,7 @@ class TestSchemaMode(TestCase):
         d = SchemaDataBag()
         self.assertEqual(str(d.data), '{}')
 
-    if DJANGO_VERSION[:2] >= (1, 8):
+    if django.VERSION >= (1, 8):
         def test_reload_schema(self):
             # cache some stuff
             f = SchemaDataBag._meta.get_field('data')
@@ -396,7 +396,7 @@ class TestSchemaMode(TestCase):
         self.assertEqual(d.char, '')
         self.assertEqual(d.number, 0)
 
-    if DJANGO_VERSION[:2] >= (1, 7):
+    if django.VERSION >= (1, 7):
         def _test_migrations_issue_103(self):
             """ failing test for https://github.com/djangonauts/django-hstore/issues/103 """
             # start capturing output
@@ -454,6 +454,6 @@ class Migration(migrations.Migration):
         def test_migrations(self):
             self._test_migrations_issue_117()
             # changes in django 1.8 make this test obsolete
-            if DJANGO_VERSION[:2] == (1, 7):
+            if django.VERSION == (1, 7):
                 self._test_migrations_issue_103()
             TestSchemaMode._delete_migrations()

--- a/tests/django_hstore_tests/tests/test_serialized_dictionary_field.py
+++ b/tests/django_hstore_tests/tests/test_serialized_dictionary_field.py
@@ -2,10 +2,10 @@
 import datetime
 
 from django import forms
-from django.db.models.aggregates import Count
+from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError
 from django.core.urlresolvers import reverse
-from django.contrib.auth.models import User
+from django.db.models.aggregates import Count
 from django.test import TestCase
 
 from django_hstore.forms import SerializedDictionaryFieldWidget

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -2,11 +2,11 @@ from __future__ import print_function
 
 import os
 import sys
+
 import django
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 SECRET_KEY = '!5myuh^d23p9$$lo5k$39x&ji!vceayg+wwt472!bgs$0!i3k4'
 

--- a/tests/settings_psycopg.py
+++ b/tests/settings_psycopg.py
@@ -2,11 +2,11 @@ from __future__ import print_function
 
 import os
 import sys
+
 import django
 
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 SECRET_KEY = '!5myuh^d23p9$$lo5k$39x&ji!vceayg+wwt472!bgs$0!i3k4'
 
@@ -67,9 +67,25 @@ USE_L10N = True
 USE_TZ = True
 STATIC_URL = '/static/'
 
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
+
 # local settings must be imported before test runner otherwise they'll be ignored
 try:
-    from local_settings_psycopg import *
+    from local_settings_psycopg import *  # noqa
 except ImportError:
     pass
 
@@ -77,7 +93,7 @@ if django.VERSION[:2] >= (1, 6):
     TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 else:
     try:
-        import discover_runner
+        import discover_runner  # noqa
         TEST_RUNNER = "discover_runner.DiscoverRunner"
     except ImportError:
         print("For run tests with django <= 1.5 you should install "

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -1,15 +1,16 @@
-from django.conf.urls import patterns, include, url
 from django.conf import settings
+from django.conf.urls import include, url
 from django.contrib import admin
+
 admin.autodiscover()
 
 
-urlpatterns = patterns('',  # noqa
+urlpatterns = [
     url(r'^admin/', include(admin.site.urls)),
-)
+]
 
 
 if 'grappelli' in settings.INSTALLED_APPS:
-    urlpatterns = urlpatterns + patterns('',  # noqa
+    urlpatterns.append([
         url(r'^grappelli/', include('grappelli.urls')),
-    )
+    ])


### PR DESCRIPTION
The `Creator` class disappears in Django 1.10 along with the removal of the `subclassing` module.
This is a bit of a naive way to keep `django-store` dj110 compatible, but maybe someone can suggest a nicer approach.
