### PR TITLE
Fix non-ascii character in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ django-hstore
 
 You need **dynamic columns** in your tables. What do you do?
 
-- Create lots of tables to handle it. Nice, now you’ll need more models and lots of additional sqls. Insertion and selection will be slow as hell.
+- Create lots of tables to handle it. Nice, now you'll need more models and lots of additional sqls. Insertion and selection will be slow as hell.
 - Use a **noSQL** database just for this issue. **Good luck**.
 - Create a serialized column. Nice, insertion will be fine, and reading data from a record too. But, what if you have a condition in your select that includes serialized data? Yeah, regular expressions.
 


### PR DESCRIPTION
When I try to build django-hstore in a minimal build environment, I get this error:

  File "setup.py", line 46, in <module>
    long_description=open('README.rst').read(),
  File "/usr/lib/python3.5/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 874: ordinal not in range(128)

This is easily fixed with a one character change.  Thanks for considering.