### PR TITLE
Fixing JS admin widget to properly update the field value

### DIFF
--- a/django_hstore/static/admin/js/django_hstore/hstore-widget.js
+++ b/django_hstore/static/admin/js/django_hstore/hstore-widget.js
@@ -163,7 +163,7 @@ var initDjangoHStoreWidget = function(hstore_field_name, inline_prefix) {
     });
 
     // update textarea whenever a field changes
-    $hstore.delegate('input[type=text]', 'keyup', function() {
+    $hstore.delegate('input[type=text]', 'input propertychange', function() {
         updateTextarea($hstore);
     });
 };


### PR DESCRIPTION
Currently, copy/paste/cut/undo events are ignored by the admin widget, it fails to update the internal field-value...saving means any copy-n-pasted text is lost (unless you also manually typed somewhere in the field too).

Only manual typing (via keyup events) works currently

This fix makes all input-changing events update the internal state of the field.

Tested in Chrome & Firefox...this is recommended as the standard cross-browser way to handle all these events.
